### PR TITLE
Add `python_version` to EC2 configuration

### DIFF
--- a/nomad/agents/base.py
+++ b/nomad/agents/base.py
@@ -122,6 +122,17 @@ class Agent(metaclass=MetaAgent):
         download_files = agent_conf["download_files"]
         return download_files
 
+    def parse_python_version(self, agent_conf: Dict[str, Any]):
+        """
+        Get the Python version to use in the cloud environment
+
+        args:
+            agent_conf: agent configuration as dictionary
+        returns:
+            Python version, as a string
+        """
+        return agent_conf["python_version"]
+
     def apply(self):
         raise ValueError("`run` method not yet implemented!")
 

--- a/nomad/agents/ec2.py
+++ b/nomad/agents/ec2.py
@@ -985,6 +985,7 @@ class Ec2(Agent):
         # Infra
         instance_type = self.parse_infra_key(self.infra.infra_conf, "instance_type")
         ami_image = self.parse_infra_key(self.infra.infra_conf, "ami_image")
+        python_version = self.parse_infra_key(self.infra.infra_conf, "python_version")
 
         # requirements.txt path
         requirements_txt_path = Path(self.parse_requirements(self.agent_conf))
@@ -1003,9 +1004,6 @@ class Ec2(Agent):
         # Environment dictionary
         env_dict = self.parse_environment_variables(self.agent_conf)
         env_cli = ",".join([f"{k}={v}" for k, v in env_dict.items()])
-
-        # Python version
-        python_version = self.parse_python_version(self.agent_conf)
 
         # Paths to copy
         all_local_paths = self.get_all_local_paths(

--- a/nomad/agents/ec2.py
+++ b/nomad/agents/ec2.py
@@ -1004,6 +1004,9 @@ class Ec2(Agent):
         env_dict = self.parse_environment_variables(self.agent_conf)
         env_cli = ",".join([f"{k}={v}" for k, v in env_dict.items()])
 
+        # Python version
+        python_version = self.parse_python_version(self.agent_conf)
+
         # Paths to copy
         all_local_paths = self.get_all_local_paths(
             self.nomad_wkdir,
@@ -1040,6 +1043,8 @@ class Ec2(Agent):
                 '-d', str(project_dir),
                 '-c', all_local_paths_cli,
                 '-e', env_cli,
+                '-v', python_version,
+
             ] + procesed_post_build_commands
 
             # Open a subprocess and stream the logs

--- a/nomad/agents/scripts/apply.sh
+++ b/nomad/agents/scripts/apply.sh
@@ -44,6 +44,9 @@ for val in "${post_build_cmds[@]}"; do
     post_build_cmds_str+="$val${NEWLINE}"
 done
 
+# python version
+python_cli="${python_version%*.*}"
+
 # Compare local requirements to remote requirements. If the two are identical, then do
 # not re-install the requirements. If they aren't, then create a new virtual environment
 # and reinstall.
@@ -80,7 +83,7 @@ if [ -d ~/.venv/${project_name} ]; then
 	true # pass
 else
 	cd ~
-	python3.11 -m venv ~/.venv/${project_name}
+	python${python_cli} -m venv ~/.venv/${project_name}
 	source ~/.venv/${project_name}/bin/activate
 	pip install --upgrade pip
 	pip install -r requirements.txt
@@ -124,7 +127,7 @@ fi
 
 # Virtual environment
 cd ~
-python3.11 -m venv ~/.venv/${project_name}
+python${python_cli} -m venv ~/.venv/${project_name}
 source ~/.venv/${project_name}/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
@@ -161,7 +164,7 @@ else
 		true
 	else
 		cd ~
-		python3.11 -m venv ~/.venv/${project_name}
+		python${python_cli} -m venv ~/.venv/${project_name}
 		source ~/.venv/${project_name}/bin/activate
 		pip install --upgrade pip
 		${post_build_cmds_str}

--- a/nomad/agents/scripts/apply.sh
+++ b/nomad/agents/scripts/apply.sh
@@ -45,7 +45,11 @@ for val in "${post_build_cmds[@]}"; do
 done
 
 # python version
-python_cli="${python_version%*.*}"
+if [ ! -z "${python_version}" ]; then
+	python_cli="${python_version%*.*}"
+else
+	python_cli="3"
+fi
 
 # Compare local requirements to remote requirements. If the two are identical, then do
 # not re-install the requirements. If they aren't, then create a new virtual environment
@@ -107,7 +111,6 @@ if [ -d ~/.venv/${project_name} ]; then
 fi
 
 # Install Python version, if it doesn't exist
-echo 'here2'
 if [ ! -z "${python_version}" ]; then
 	if ! test -f ~/Python-${python_version}.tgz; then
 		echo 'Installing Python ${python_version}...'

--- a/nomad/agents/scripts/apply.sh
+++ b/nomad/agents/scripts/apply.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while getopts r:p:u:n:d:c:e:x: flag
+while getopts r:p:u:n:d:c:e:x:v: flag
 do
 	case "${flag}" in
 		r) requirements=${OPTARG};;
@@ -11,6 +11,7 @@ do
 		c) copy_paths=${OPTARG};;
 		e) env=${OPTARG};;
 		x) post_build_cmds+=("$OPTARG");;
+		v) python_version=${OPTARG};;
 	esac
 done
 
@@ -57,10 +58,29 @@ if [ ! -z "${requirements}" ]; then
 	if diff $local_file $temp_file >/dev/null ; then
 
 		ssh -i ${pem_path} ${user}@${public_dns_name} <<EOF
+# Install Python version, if it doesn't exist
+if [ ! -z "${python_version}" ]; then
+	if ! test -f ~/Python-${python_version}.tgz; then
+		echo 'Installing Python ${python_version}...'
+		
+		# Some dependencies
+		sudo yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel -y
+
+		wget https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz
+		tar xzf Python-${python_version}.tgz
+		cd Python-${python_version}
+		sudo ./configure --enable-optimizations
+		sudo make altinstall
+
+		echo 'Done installing Python ${python_version}...'
+	fi
+fi
+
 if [ -d ~/.venv/${project_name} ]; then
 	true # pass
 else
-	python3 -m venv ~/.venv/${project_name}
+	cd ~
+	python3.11 -m venv ~/.venv/${project_name}
 	source ~/.venv/${project_name}/bin/activate
 	pip install --upgrade pip
 	pip install -r requirements.txt
@@ -82,7 +102,29 @@ EOF
 if [ -d ~/.venv/${project_name} ]; then
 	sudo rm -rf ~/.venv/${project_name}
 fi
-python3 -m venv ~/.venv/${project_name}
+
+# Install Python version, if it doesn't exist
+echo 'here2'
+if [ ! -z "${python_version}" ]; then
+	if ! test -f ~/Python-${python_version}.tgz; then
+		echo 'Installing Python ${python_version}...'
+
+		# Some dependencies
+		sudo yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel -y
+
+		wget https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz
+		tar xzf Python-${python_version}.tgz
+		cd Python-${python_version}
+		sudo ./configure --enable-optimizations
+		sudo make altinstall
+
+		echo 'Done installing Python ${python_version}...'
+	fi
+fi
+
+# Virtual environment
+cd ~
+python3.11 -m venv ~/.venv/${project_name}
 source ~/.venv/${project_name}/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
@@ -96,10 +138,30 @@ EOF
 else
 	# Create a virtual environment, but just don't install anything
 	ssh -i ${pem_path} ${user}@${public_dns_name} <<EOF
+	# Install Python version, if it doesn't exist
+	if [ ! -z "${python_version}" ]; then
+		if ! test -f ~/Python-${python_version}.tgz; then
+			echo 'Installing Python ${python_version}...'
+
+			# Some dependencies
+			sudo yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel -y
+			
+			wget https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz
+			tar xzf Python-${python_version}.tgz
+			cd Python-${python_version}
+			sudo ./configure --enable-optimizations
+			sudo make altinstall
+
+			echo 'Done installing Python ${python_version}...'
+		fi
+	fi
+
+	# Virtual environment
 	if [ -d ~/.venv/${project_name} ]; then
 		true
 	else
-		python3 -m venv ~/.venv/${project_name}
+		cd ~
+		python3.11 -m venv ~/.venv/${project_name}
 		source ~/.venv/${project_name}/bin/activate
 		pip install --upgrade pip
 		${post_build_cmds_str}

--- a/nomad/tasks/base.py
+++ b/nomad/tasks/base.py
@@ -361,6 +361,8 @@ class BaseTask:
             # specified first.
             for li in lis:
                 matches = re.search("Python (.*)$", li.contents[0])
+                if matches is None:
+                    continue
                 _version = matches.group(1)
 
                 # Find the first Python version that agrees with the inputted "major" /

--- a/nomad/tasks/base.py
+++ b/nomad/tasks/base.py
@@ -6,8 +6,6 @@ Base task class
 import argparse
 from pathlib import Path
 from typing import Any, Dict
-import re
-import requests
 
 
 # Internal imports
@@ -80,7 +78,6 @@ class BaseTask:
         self.confirm_matrix_conf_structure(self.conf)
         self.confirm_entrypoint_conf_structure(self.conf)
         self.confirm_additional_paths_conf_structure(self.conf)
-        self.conf = self.define_python_version(self.conf)
         self.conf = self.define_post_build_cmds(self.conf)
         self.conf = self.define_download_files(self.conf)
 
@@ -129,7 +126,6 @@ class BaseTask:
 
         # Other optional keys
         optional_keys = [
-            ConfigurationKey("python_version", [str, int, float]),
             ConfigurationKey("env", dict),
             ConfigurationKey("requirements", str),
             ConfigurationKey("post_build_cmds", list),
@@ -301,93 +297,3 @@ class BaseTask:
         # Update configuration
         conf["download_files"] = download_files
         return conf
-
-    def define_python_version(self,
-        conf: Dict[str, Any]
-    ):
-        if "python_version" not in conf.keys():
-            conf["python_version"] = ""
-            return conf
-
-        # Grab / update the python version
-        python_version = str(conf["python_version"])
-
-        # Check if major, minor, and micro version are all specified
-        _split = python_version.split(".")
-        if len(_split) > 3:
-            raise ValueError(f"invalid Python version `{python_version}`")
-        version_format = ""
-        if len(_split) == 1:
-            version_format = "major"
-        elif len(_split) == 2:
-            version_format = "major.minor"
-        else:
-            version_format = "major.minor.micro"
-
-        # If a full version of Python is specified, then confirm that it exists and
-        # return that.
-        if version_format == "major.minor.micro":
-            resp = requests.get(f"https://www.python.org/ftp/python/{python_version}/")
-            if resp.status_code != 200:
-                resp.raise_for_status()
-
-            conf["python_version"] = python_version
-            return conf
-
-        # If only the major or major/minor are specified, then grab the latest
-        # associated version of Python.
-        else:
-
-            # Place imports in this inner `if` clause, because we don't want to import
-            # stuff unnecessarily.
-            from bs4 import BeautifulSoup
-
-            # Get all available versions
-            url = "https://www.python.org/doc/versions/"
-            response = requests.get(url)
-            soup = BeautifulSoup(response.text, "html.parser")
-
-            # All python versions are stored in a single div
-            div = soup.find("div", attrs={"id": "python-documentation-by-version"})
-
-            # Python versions are stored in <li> elements, i.e., something like
-            #   <li>
-            #       <a class="reference external" href="https://docs.python.org/release/3.11.0/">Python 3.11.0</a>  # noqa
-            #       " , documentation released on 24 October 2022."
-            #   </li>
-            lis = div.find_all("a", class_="reference external")
-
-            # Versions are specified in descending order, with the most recent version
-            # specified first.
-            for li in lis:
-                matches = re.search("Python (.*)$", li.contents[0])
-                if matches is None:
-                    continue
-                _version = matches.group(1)
-
-                # Find the first Python version that agrees with the inputted "major" /
-                # "major.minor" version.
-                if version_format == "major":
-                    if _version.split(".")[0] == python_version:
-
-                        # Check that the version exists in Python's archive
-                        resp = requests.get(f"https://www.python.org/ftp/python/{_version}/")  # noqa: E501
-                        if resp.status_code != 200:
-                            resp.raise_for_status()
-
-                        # If it does, return
-                        conf["python_version"] = _version
-                        return conf
-
-                elif version_format == "major.minor":
-                    _version_split = _version.split(".")
-                    if f"{_version_split[0]}.{_version_split[1]}" == python_version:
-
-                        # Check that the version exists in Python's archive
-                        resp = requests.get(f"https://www.python.org/ftp/python/{_version}/")  # noqa: E501
-                        if resp.status_code != 200:
-                            resp.raise_for_status()
-
-                        # If it does, return
-                        conf["python_version"] = _version
-                        return conf

--- a/nomad/tasks/base.py
+++ b/nomad/tasks/base.py
@@ -312,7 +312,7 @@ class BaseTask:
         # Grab / update the python version
         python_version = str(conf["python_version"])
 
-        # Check if major, minor, and patch version are all specified
+        # Check if major, minor, and micro version are all specified
         _split = python_version.split(".")
         if len(_split) > 3:
             raise ValueError(f"invalid Python version `{python_version}`")
@@ -322,11 +322,11 @@ class BaseTask:
         elif len(_split) == 2:
             version_format = "major.minor"
         else:
-            version_format = "major.minor.patch"
+            version_format = "major.minor.micro"
 
         # If a full version of Python is specified, then confirm that it exists and
         # return that.
-        if version_format == "major.minor.patch":
+        if version_format == "major.minor.micro":
             resp = requests.get(f"https://www.python.org/ftp/python/{python_version}/")
             if resp.status_code != 200:
                 resp.raise_for_status()

--- a/nomad/tests/confs/bad_python_version_format.yml
+++ b/nomad/tests/confs/bad_python_version_format.yml
@@ -1,0 +1,18 @@
+my_cloud_agent:
+  infra:
+    type: ec2
+    instance_type: t2.micro
+    ami_image: ami-01c647eace872fc02
+  requirements: requirements.txt
+  python_version: 3.11.89
+  entrypoint:
+    type: function
+    src: scripts
+    cmd: test_fn.print_value
+    kwargs:
+      value: "hello world"
+  additional_paths:
+    - "{{ Path(__file__).parent }}"
+  env:
+    ENV_VAR_1: VALUE1
+    ENV_VAR_2: VALUE2

--- a/nomad/tests/confs/python_major.yml
+++ b/nomad/tests/confs/python_major.yml
@@ -1,0 +1,18 @@
+my_cloud_agent:
+  infra:
+    type: ec2
+    instance_type: t2.micro
+    ami_image: ami-01c647eace872fc02
+  requirements: requirements.txt
+  python_version: 2
+  entrypoint:
+    type: function
+    src: scripts
+    cmd: test_fn.print_value
+    kwargs:
+      value: "hello world"
+  additional_paths:
+    - "{{ Path(__file__).parent }}"
+  env:
+    ENV_VAR_1: VALUE1
+    ENV_VAR_2: VALUE2

--- a/nomad/tests/confs/python_major_minor.yml
+++ b/nomad/tests/confs/python_major_minor.yml
@@ -1,0 +1,18 @@
+my_cloud_agent:
+  infra:
+    type: ec2
+    instance_type: t2.micro
+    ami_image: ami-01c647eace872fc02
+  requirements: requirements.txt
+  python_version: 3.6
+  entrypoint:
+    type: function
+    src: scripts
+    cmd: test_fn.print_value
+    kwargs:
+      value: "hello world"
+  additional_paths:
+    - "{{ Path(__file__).parent }}"
+  env:
+    ENV_VAR_1: VALUE1
+    ENV_VAR_2: VALUE2

--- a/nomad/tests/confs/python_major_minor_patch.yml
+++ b/nomad/tests/confs/python_major_minor_patch.yml
@@ -1,0 +1,18 @@
+my_cloud_agent:
+  infra:
+    type: ec2
+    instance_type: t2.micro
+    ami_image: ami-01c647eace872fc02
+  requirements: requirements.txt
+  python_version: "3.11.6"
+  entrypoint:
+    type: function
+    src: scripts
+    cmd: test_fn.print_value
+    kwargs:
+      value: "hello world"
+  additional_paths:
+    - "{{ Path(__file__).parent }}"
+  env:
+    ENV_VAR_1: VALUE1
+    ENV_VAR_2: VALUE2

--- a/nomad/tests/infras/ec2_tests.py
+++ b/nomad/tests/infras/ec2_tests.py
@@ -19,3 +19,43 @@ BAD_INSTANCE_TYPE = {
     "type": "ec2",
     "instance_type": "t2.abcedfg",
 }
+
+
+# --------------------------------------------------------------------------------------
+# Python version (major only)
+
+PYTHON_VERSION_MAJOR = {
+    "type": "ec2",
+    "instance_type": "c1.medium",
+    "python_version": 2,
+}
+
+
+# --------------------------------------------------------------------------------------
+# Python version (major, minor)
+
+PYTHON_VERSION_MAJOR_MINOR = {
+    "type": "ec2",
+    "instance_type": "c1.medium",
+    "python_version": 3.6,
+}
+
+
+# --------------------------------------------------------------------------------------
+# Python version (major, minor, micro)
+
+PYTHON_VERSION_MAJOR_MINOR_MICRO = {
+    "type": "ec2",
+    "instance_type": "c1.medium",
+    "python_version": "3.11.6",
+}
+
+
+# --------------------------------------------------------------------------------------
+# Bad Python version
+
+BAD_PYTHON_VERSION = {
+    "type": "ec2",
+    "instance_type": "c1.medium",
+    "python_version": "3.11.89",
+}

--- a/nomad/tests/integration/function/main.py
+++ b/nomad/tests/integration/function/main.py
@@ -5,6 +5,7 @@ Example function for test case.
 # Imports
 import os
 import boto3
+import sys
 
 
 # Functions
@@ -29,5 +30,15 @@ def write_txt_file(
         platform=platform,
         python_version=python_version,
         output_name=output_name,
+    ).encode()
+    s3_object.put(Body=txt_data)
+
+    # Generate file that contains the EC2 instance's Python version
+    output_key = f"{platform}_{python_version}_ec2sys".replace(".", "")
+    s3_object = s3.Object('nomad-dev-tests', f'tests/{output_key}.txt')
+    txt_data = "This was created using Python {major}.{minor}.{micro}".format(  # noqa
+        major=sys.version_info.major,
+        minor=sys.version_info.minor,
+        micro=sys.version_info.micro
     ).encode()
     s3_object.put(Body=txt_data)

--- a/nomad/tests/integration/function/nomad.yml
+++ b/nomad/tests/integration/function/nomad.yml
@@ -3,6 +3,7 @@ my_cloud_agent-{{ __platform__ }}-{{ __version__ }}:
     type: ec2
     instance_type: t2.micro
     ami_image: ami-01c647eace872fc02
+    python_version: 3.11
   entrypoint:
     type: function
     cmd: main.write_txt_file

--- a/nomad/tests/integration/test_build.py
+++ b/nomad/tests/integration/test_build.py
@@ -60,6 +60,14 @@ def test_function():
     """
     _build_integration_test(TEST_FUNCTION, "test_function")
 
+    # Check that the correct Python version was used
+    output_key = f"{PLATFORM}_{PYTHON_VERSION}_ec2sys"
+    file_s3_uri = f"s3://nomad-dev-tests/tests/{output_key}.txt"
+    test_output = s3_file_exists(file_s3_uri)
+    expected_output = "This was created using Python 3.11.6"
+    assert test_output == expected_output
+    delete_s3_file(file_s3_uri)
+
 
 def test_script():
     """

--- a/nomad/tests/integration/test_build.py
+++ b/nomad/tests/integration/test_build.py
@@ -61,7 +61,7 @@ def test_function():
     _build_integration_test(TEST_FUNCTION, "test_function")
 
     # Check that the correct Python version was used
-    output_key = f"{PLATFORM}_{PYTHON_VERSION}_ec2sys"
+    output_key = f"{PLATFORM}_{PYTHON_VERSION}_ec2sys".replace(".", "")
     file_s3_uri = f"s3://nomad-dev-tests/tests/{output_key}.txt"
     test_output = s3_file_exists(file_s3_uri)
     expected_output = "This was created using Python 3.11.6"

--- a/nomad/tests/test_base_task.py
+++ b/nomad/tests/test_base_task.py
@@ -7,7 +7,6 @@ import argparse
 from pathlib import Path
 from nomad.tasks.base import BaseTask
 import pytest
-import requests
 
 
 # Constants
@@ -42,6 +41,7 @@ def test_normal_conf():
             "type": "ec2",
             "instance_type": "t2.micro",
             "ami_image": "ami-01c647eace872fc02",
+            "python_version": "",
         },
         "requirements": "requirements.txt",
         "entrypoint": {
@@ -60,7 +60,6 @@ def test_normal_conf():
             "ENV_VAR_2": "VALUE2",
         },
         "download_files": [],
-        "python_version": "",
     }
     assert expected_conf == task.conf
 
@@ -184,6 +183,7 @@ def test_jupyter_entrypoint():
             "type": "ec2",
             "instance_type": "t2.micro",
             "ami_image": "ami-01c647eace872fc02",
+            "python_version": "",
         },
         "requirements": "requirements.txt",
         "entrypoint": {
@@ -203,45 +203,5 @@ def test_jupyter_entrypoint():
         "download_files": [
             "scripts/nomad_nb_exec.ipynb",
         ],
-        "python_version": "",
     }
     assert expected_conf == task.conf
-
-
-def test_python_major():
-    """
-    Test Python version when only the `major` version is specified. The `major` version
-    is 2.
-    """
-    task = _create_task(path=(CONFs / 'python_major.yml'))
-    task.check()
-    assert "2.7.18" == task.conf["python_version"]
-
-
-def test_python_major_minor():
-    """
-    Test Python version when the `major` and `minor` versions are specified.
-    """
-    task = _create_task(path=(CONFs / 'python_major_minor.yml'))
-    task.check()
-    assert "3.6.15" == task.conf["python_version"]
-
-
-def test_python_major_minor_micro():
-    """
-    Test Python version when the `major`, `minor`, and `micro` are all specified
-    """
-    task = _create_task(path=(CONFs / 'python_major_minor_micro.yml'))
-    task.check()
-    assert "3.11.6" == task.conf["python_version"]
-
-
-def test_python_bad_version():
-    """
-    Test Python version when the `major`, `minor`, and `micro` are all specified
-    """
-    task = _create_task(path=(CONFs / 'bad_python_version_format.yml'))
-    with pytest.raises(requests.exceptions.HTTPError) as cm:
-        task.check()
-    expected_msg = "404 Client Error: Not Found for url: https://www.python.org/ftp/python/3.11.89/"  # noqa
-    assert expected_msg == str(cm.value)

--- a/nomad/tests/test_base_task.py
+++ b/nomad/tests/test_base_task.py
@@ -227,18 +227,18 @@ def test_python_major_minor():
     assert "3.6.15" == task.conf["python_version"]
 
 
-def test_python_major_minor_patch():
+def test_python_major_minor_micro():
     """
-    Test Python version when the `major`, `minor`, and `patch` are all specified
+    Test Python version when the `major`, `minor`, and `micro` are all specified
     """
-    task = _create_task(path=(CONFs / 'python_major_minor_patch.yml'))
+    task = _create_task(path=(CONFs / 'python_major_minor_micro.yml'))
     task.check()
     assert "3.11.6" == task.conf["python_version"]
 
 
 def test_python_bad_version():
     """
-    Test Python version when the `major`, `minor`, and `patch` are all specified
+    Test Python version when the `major`, `minor`, and `micro` are all specified
     """
     task = _create_task(path=(CONFs / 'bad_python_version_format.yml'))
     with pytest.raises(requests.exceptions.HTTPError) as cm:

--- a/nomad/utils.py
+++ b/nomad/utils.py
@@ -37,10 +37,27 @@ def _check_key_in_conf(
             f"`{_k.key_name}` not found in `{conf_name}`'s configuration!"
         )
     _v = conf[_k.key_name]
-    if not isinstance(_v, _k.key_type):
-        raise ValueError(
-            f"`{_k.key_name}` is not the correct type...should be a {str(_k.key_type)}"
-        )
+
+    # The `key_type` property can be either a single type or a list of types
+    if not isinstance(_k.key_type, list):
+        if not isinstance(_v, _k.key_type):
+            raise ValueError(
+                f"`{_k.key_name}` is not the correct type...should be a {str(_k.key_type)}"  # noqa: E501
+            )
+
+    # For a list of types, check if the inputted value is any of the inputted types.
+    else:
+        flag_any_type = False
+        for _type in _k.key_type:
+            if isinstance(_v, _type):
+                flag_any_type = True
+
+        # Check if any of the inputted types were recognized
+        if not flag_any_type:
+            raise ValueError(
+                f"`{_k.key_name}` is not the correct type...should be one of {str(_k.key_type)}"  # noqa: E501
+            )
+
     if _k.key_supported_values is not None:
         if _v not in _k.key_supported_values:
             raise ValueError(

--- a/nomad/utils.py
+++ b/nomad/utils.py
@@ -4,14 +4,14 @@ Util functions
 
 # Imports
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Optional, List, Union
 
 
 # Functions / Utils
 @dataclass
 class ConfigurationKey:
     key_name: str
-    key_type: type
+    key_type: Union[type, List[type]]
     key_supported_values: Optional[List[str]] = None
 
 
@@ -70,10 +70,26 @@ def _check_optional_key_in_conf(
         return True
 
     _v = conf[_k.key_name]
-    if not isinstance(_v, _k.key_type):
-        raise ValueError(
-            f"`{_k.key_name}` is not the correct type...should be a {str(_k.key_type)}"
-        )
+
+    # The `key_type` property can be either a single type or a list of types
+    if not isinstance(_k.key_type, list):
+        if not isinstance(_v, _k.key_type):
+            raise ValueError(
+                f"`{_k.key_name}` is not the correct type...should be a {str(_k.key_type)}"  # noqa: E501
+            )
+
+    # For a list of types, check if the inputted value is any of the inputted types.
+    else:
+        flag_any_type = False
+        for _type in _k.key_type:
+            if isinstance(_v, _type):
+                flag_any_type = True
+
+        # Check if any of the inputted types were recognized
+        if not flag_any_type:
+            raise ValueError(
+                f"`{_k.key_name}` is not the correct type...should be one of {str(_k.key_type)}"  # noqa: E501
+            )
     if _k.key_supported_values is not None:
         if _v not in _k.key_supported_values:
             raise ValueError(

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ zip_safe = no
 [options.extras_require]
 testing = 
     pytest>=7
+    types-requests
     build>=0.10
     twine>=4.0
 jupyter =

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ zip_safe = no
 [options.extras_require]
 testing = 
     pytest>=7
-    types-requests
     build>=0.10
     twine>=4.0
 jupyter =

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     coolname>=2.2
     shortuuid>=1.0
     rich_click>=1.6.1
+    beautifulsoup4>=4.12
 python_requires = >=3.8
 zip_safe = no
 

--- a/style_requirements.txt
+++ b/style_requirements.txt
@@ -4,3 +4,4 @@ typed-ast
 types-PyYAML
 flake8
 boto3-stubs
+types-requests


### PR DESCRIPTION
- Add the option to specify a `major`, `major.minor`, or `major.minor.micro` version of Python.